### PR TITLE
update: scope the error to inform about the PR number

### DIFF
--- a/pkg/releasenotes/releasenotes.go
+++ b/pkg/releasenotes/releasenotes.go
@@ -82,7 +82,7 @@ func (c *Client) Get(org, repo, branch, milestone string) ([]ReleaseNote, error)
 			n = strings.Trim(n, "\r")
 			matches := typologyRegexp.FindStringSubmatch(n)
 			if len(matches) < 5 {
-				return nil, fmt.Errorf("error extracting type from release note")
+				return nil, fmt.Errorf("error extracting type from release note, pr: %d", p.GetNumber())
 			}
 
 			rn := ReleaseNote{


### PR DESCRIPTION
This is particularly useful when the release notes
are not respecting the format we want.

In that case, the user needs to be informed about the note
that is causing everything to stop. The PR number is sufficient
to do such lookup.

Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>