### PR TITLE
new(cmd): added a composite action to use rn2md as a github workflow step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test composite action
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+  workflow_dispatch:    
+
+jobs:
+  test-composite-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    
+      - name: generate release notes for Falco 0.36.0
+        id: generate
+        uses: ./
+        with:
+          branch: master
+          repo: falcosecurity/falco
+          output: test.md
+          milestone: '0.36.0'
+
+      - name: show output file
+        run: cat test.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# release note to markdown
+# release notes to markdown
 
 > Generate markdown for your changelogs from release-note blocks
 
@@ -11,14 +11,14 @@ For example `new: ...` and `BREAKING CHANGE: ...` release-note rows populate the
 ## Usage
 
 ```bash
-rn2md -o falcosecurity -m 0.21.0 -r falco
+rn2md -r falcosecurity/falco -m 0.21.0
 ```
 
 ## Help
 
 ```
 ./rn2md --help
-Little configurable CLI to generate the markdown for your changelos from release-note blocks found into your project pull requests.
+Little configurable CLI to generate the markdown for your changelogs from release-note blocks found into your project pull requests.
 
 Usage:
   rn2md [flags]
@@ -27,9 +27,28 @@ Flags:
   -b, --branch string      the target branch you want to filter by the pull requests (default "master")
   -h, --help               help for rn2md
   -m, --milestone string   the milestone you want to filter by the pull requests
-  -o, --org string         the github organization
-  -r, --repo string        the github repository name
+  -r, --repo string        the full github repository name (org/repo)
   -t, --token string       a GitHub personal API token to perform authenticated requests
+```
+
+## Using the github action in your repo
+
+To automatically generate release notes markdown for your project milestone, you must just add a step to your workflow.
+
+```yaml
+  - name: rn2md
+    uses: leodido/rn2md@latest
+    with:
+      # The milestone you want to filter by the pull requests. Required.
+      milestone: 0.21.0
+      # A github token needed for the github client API calls (listing repo PRs). Defaults to ${{ github.token }}
+      token: mytoken
+      # Full name for your repo. Defaults to ${{ github.repository }}
+      repo: myorg/myrepo 
+      # Target branch to filter by the pull requests. Defaults to ${{ github.event.repository.default_branch }}.
+      branch: main
+      # Target file to be generated. Defaults to ${{ github.workspace }}/release_body.md
+      output: out.md
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To automatically generate release notes markdown for your project milestone, you
 
 ```yaml
   - name: rn2md
-    uses: leodido/rn2md@latest
+    uses: leodido/rn2md@master
     with:
       # The milestone you want to filter by the pull requests. Required.
       milestone: 0.21.0
@@ -47,7 +47,7 @@ To automatically generate release notes markdown for your project milestone, you
       repo: myorg/myrepo 
       # Target branch to filter by the pull requests. Defaults to ${{ github.event.repository.default_branch }}.
       branch: main
-      # Target file to be generated. Defaults to ${{ github.workspace }}/release_body.md
+      # Target file to be generated, relative to github workspace. Defaults to release_body.md
       output: out.md
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,45 @@
+name: 'rn2md'
+description: 'Generate release notes and stats from release-note blocks found into your project pull requests.'
+
+outputs:
+  path:
+    description: Path for the output file
+    value: ${{ steps.generate.outputs.path }}
+
+inputs:
+  token:
+    description: A GitHub personal API token to perform authenticated requests
+    required: false
+    default: ${{ github.token }}
+  milestone:
+    description: The milestone you want to filter by the pull requests
+    required: true
+  repo:
+    description: The github repository name
+    required: false
+    default: ${{ github.repository }}
+  branch:
+    description: The target branch you want to filter by the pull requests
+    required: false
+    default: ${{ github.event.repository.default_branch }}
+  output:
+    description: Target file to be generated
+    required: false
+    default: ${{ github.workspace }}/release_body.md
+
+runs:
+  using: "composite"
+  steps:
+    - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
+      shell: bash
+  
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.21
+        
+    - id: generate
+      run: |
+        go build .
+        ./rn2md -b ${{ inputs.branch }} -r ${{ inputs.repo }} -m ${{ inputs.milestone }} -t ${{ inputs.token }} &> ${{ inputs.output }}
+        PATH=$(${{ inputs.output }})
+        echo "path=${PATH}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -23,23 +23,21 @@ inputs:
     required: false
     default: ${{ github.event.repository.default_branch }}
   output:
-    description: Target file to be generated
+    description: Target file to be generated, relative to github workspace
     required: false
-    default: ${{ github.workspace }}/release_body.md
+    default: release_body.md
 
 runs:
   using: "composite"
   steps:
-    - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
-      shell: bash
-  
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v4
       with:
         go-version: 1.21
         
     - id: generate
+      shell: bash
+      working-directory: ${{ github.action_path }}
       run: |
         go build .
-        ./rn2md -b ${{ inputs.branch }} -r ${{ inputs.repo }} -m ${{ inputs.milestone }} -t ${{ inputs.token }} &> ${{ inputs.output }}
-        PATH=$(${{ inputs.output }})
-        echo "path=${PATH}" >> $GITHUB_OUTPUT
+        ./rn2md -b ${{ inputs.branch }} -r ${{ inputs.repo }} -m ${{ inputs.milestone }} -t ${{ inputs.token }} &> "${{ github.workspace }}/${{ inputs.output }}"
+        echo "path=${{ github.workspace }}/${{ inputs.output }}" >> $GITHUB_OUTPUT

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/creasty/defaults"
 	"github.com/go-playground/validator/v10"
@@ -13,7 +14,6 @@ import (
 type Options struct {
 	Milestone string `validate:"required,semver" name:"milestone"`
 	Branch    string `default:"master" validate:"omitempty,ascii" name:"branch"`
-	Org       string `validate:"required,ascii" name:"organization"`
 	Repo      string `validate:"required,ascii" name:"repository"`
 	Token     string `validate:"omitempty,len=40" name:"token"`
 }
@@ -39,4 +39,12 @@ func (o *Options) Validate() []error {
 		return errArr
 	}
 	return nil
+}
+
+func (o *Options) SplitRepoOrgName() (string, string, error) {
+	names := strings.Split(o.Repo, "/")
+	if len(names) != 2 {
+		return "", "", fmt.Errorf("provided repo has wrong format, expected org/repo, actual: %s", o.Repo)
+	}
+	return names[0], names[1], nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,11 @@ var program = &cobra.Command{
 	},
 	Run: func(c *cobra.Command, args []string) {
 		client := releasenotes.NewClient(opts.Token)
-		notes, stats, err := client.Get(opts.Org, opts.Repo, opts.Branch, opts.Milestone)
+		org, repo, err := opts.SplitRepoOrgName()
+		if err != nil {
+			logger.WithError(err).Fatal("error retrieving repo org and name")
+		}
+		notes, stats, err := client.Get(org, repo, opts.Branch, opts.Milestone)
 		if err != nil {
 			logger.WithError(err).Fatal("error retrieving PRs")
 		}
@@ -47,8 +51,7 @@ func init() {
 	// Setup flags before the command is initialized
 	flags := program.PersistentFlags()
 	flags.StringVarP(&opts.Milestone, "milestone", "m", opts.Milestone, "the milestone you want to filter by the pull requests")
-	flags.StringVarP(&opts.Org, "org", "o", opts.Org, "the github organization")
-	flags.StringVarP(&opts.Repo, "repo", "r", opts.Repo, "the github repository name")
+	flags.StringVarP(&opts.Repo, "repo", "r", opts.Repo, "the full github repository name (org/repo)")
 	flags.StringVarP(&opts.Branch, "branch", "b", opts.Branch, "the target branch you want to filter by the pull requests")
 	flags.StringVarP(&opts.Token, "token", "t", opts.Token, "a GitHub personal API token to perform authenticated requests")
 }


### PR DESCRIPTION
Also, updated `--repo` cmdline option to take full repo name (ie: org/name), to match github action context value (ie: `${{ github.repository }}`) that is used as a default value for the composite action.

NOTE: tested here:  https://github.com/FedeDP/rn2md/actions/runs/6199271859

Fixes #9

Moreover, PR also contains a test for the composite action that gets triggered whenever anyone modifies the `action.yml` file (or can be manually dispatched).